### PR TITLE
[refactor] Drop Python2

### DIFF
--- a/download.py
+++ b/download.py
@@ -1,9 +1,8 @@
 from __future__ import print_function
 import os
 import re
-from six.moves.urllib.request import urlopen
-from six.moves.urllib.error import HTTPError
-import urllib2
+from urllib.request import urlopen
+from urllib.error import HTTPError
 import shutil
 import argparse
 import mistune
@@ -12,12 +11,6 @@ import socket
 import time
 import requests
 
-# encoding=utf8  
-import sys  
-
-reload(sys)  
-sys.setdefaultencoding('utf8')
-
 def download_pdf(link, location, name):
     try:
         response = requests.get(link)
@@ -25,15 +18,15 @@ def download_pdf(link, location, name):
         	f.write(response.content)
         	f.close()
     except HTTPError:
-        print('>>> Error 404: cannot be downloaded!\n') 
-        raise   
+        print('>>> Error 404: cannot be downloaded!\n')
+        raise
     except socket.timeout:
         print(" ".join(("can't download", link, "due to connection timeout!")) )
         raise
 
 def clean_pdf_link(link):
     if 'arxiv' in link:
-        link = link.replace('abs', 'pdf')   
+        link = link.replace('abs', 'pdf')
         if not(link.endswith('.pdf')):
             link = '.'.join((link, 'pdf'))
 
@@ -43,18 +36,18 @@ def clean_pdf_link(link):
 def clean_text(text, replacements = {':': '_', ' ': '_', '/': '_', '.': '', '"': ''}):
     for key, rep in replacements.items():
         text = text.replace(key, rep)
-    return text    
+    return text
 
 def print_title(title, pattern = "-"):
-    print('\n'.join(("", title, pattern * len(title)))) 
+    print('\n'.join(("", title, pattern * len(title))))
 
 def get_extension(link):
     extension = os.path.splitext(link)[1][1:]
     if extension in ['pdf', 'html']:
         return extension
     if 'pdf' in extension:
-        return 'pdf'    
-    return 'pdf'    
+        return 'pdf'
+    return 'pdf'
 
 def shorten_title(title):
     m1 = re.search('[[0-9]*]', title)
@@ -62,8 +55,8 @@ def shorten_title(title):
     if m1:
         title = m1.group(0)
     if m2:
-        title = ' '.join((title, m2.group(0)))   
-    return title[:50] + ' [...]'    
+        title = ' '.join((title, m2.group(0)))
+    return title[:50] + ' [...]'
 
 
 if __name__ == '__main__':
@@ -71,7 +64,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description = 'Download all the PDF/HTML links into README.md')
     parser.add_argument('-d', action="store", dest="directory")
     parser.add_argument('--no-html', action="store_true", dest="nohtml", default = False)
-    parser.add_argument('--overwrite', action="store_true", default = False)    
+    parser.add_argument('--overwrite', action="store_true", default = False)
     results = parser.parse_args()
 
     output_directory = 'pdfs' if results.directory is None else results.directory
@@ -95,7 +88,7 @@ if __name__ == '__main__':
                     h1_directory = os.path.join(output_directory, clean_text(point.text))
                     current_directory = h1_directory
                 elif point.name == 'h2':
-                    current_directory = os.path.join(h1_directory, clean_text(point.text))  
+                    current_directory = os.path.join(h1_directory, clean_text(point.text))
                 if not os.path.exists(current_directory):
                     os.makedirs(current_directory)
                 print_title(point.text)
@@ -122,8 +115,8 @@ if __name__ == '__main__':
                                 break
                         except:
                             failures.append(point.text)
-                        
-        point = point.next_sibling          
+
+        point = point.next_sibling
 
     print('Done!')
     if failures:


### PR DESCRIPTION
## Summary

1. `urllib2` is no longer available in Python3
1. Remove trailing spaces